### PR TITLE
feat: Introduce NoneType Handling in Protobuf Generation and Tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ rpc_files/
 tests/**/*.py
 tests/**/*.pyi
 !tests/**/test_*.py
+.coverage


### PR DESCRIPTION
This pull request further extends `pydantic-rpc`’s gRPC support by adding full handling of “empty” (None) inputs/outputs, implementing combined-service .proto generation, and adding tests to cover these new code paths.

### New Features & Enhancements

* **Empty-message (`None`) Support and ServicerContext Handling**  
  * Introduces an `is_none_type` type guard and special-case converters in `generate_converter` and `generate_message_converter` so that Python methods taking or returning `None` map to `google.protobuf.Empty`.
  * Server-stub wrappers (`connect_obj_with_stub`, async variants, and Connecpy integrations) now detect `None` input/output and inject or emit `empty_pb2.Empty()` accordingly, rather than erroring or omitting arguments.
  * `.proto` generator (`generate_proto`) treats `None` as `google.protobuf.Empty` for request/response types, validates against streaming `Empty` (rejecting `AsyncIterator[None]`), and adds the corresponding `import "google/protobuf/empty.proto";` only when needed.
  * Generation now properly handles presence of ServicerContext during generation to avoid considering it as a valid message argument, and instead treats a method as Empty if no message request param is found.

* **Combined-service .proto Generation**  
  * New optional flag `PYDANTIC_RPC_COMBINED_PROTO` allows use of `generate_combined_proto` and `generate_combined_descriptor_set`, allowing multiple service classes to be rendered into a single `.proto` (and descriptor set) with shared messages and imports as a library helper functionality. This does not directly affect generation and is meant to be used in downstream code.

* **Code Cleanup, Fixes & Refactor**
  * Updated typing imports (`cast`, `TypeGuard`, `Union`) and minor signature tweaks for consistency.
  * Fixed some minor edge cases for proto generation from endpoint definition.

* **.gitignore Update**  
  * Adds `.coverage` to ignore coverage artifacts.

### Test Suite & Code Quality

* **Expanded Coverage for Empty Support**
  * Added `test_none_input_type`, `test_none_output_type`, and `test_none_both_input_and_output` to verify `generate_proto` emits `Empty`-based RPCs.  
  * New bidirectional tests (`test_bidirectional_conversion_none_input`, `test_bidirectional_conversion_none_output`) exercise `generate_message_converter(None)` with `empty_pb2.Empty` messages.
  * Async streaming rejection tests (`test_async_iterator_none_rejection`) ensure `AsyncIterator[None]` is disallowed.
