### PR TITLE
feat: add protobuf options support

### DIFF
--- a/examples/bookstore_with_http_options.py
+++ b/examples/bookstore_with_http_options.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python
+"""
+Example bookstore service with HTTP options for proto generation.
+
+This demonstrates how to use the new protobuf options feature to define
+HTTP mappings for your gRPC services.
+"""
+
+from typing import List, Optional
+from pydantic_rpc import Message, http_option, proto_option, generate_proto
+
+
+class Book(Message):
+    """Book model."""
+
+    id: str
+    title: str
+    author: str
+    isbn: Optional[str] = None
+    price: float
+
+
+class GetBookRequest(Message):
+    """Request for getting a book."""
+
+    id: str
+
+
+class ListBooksRequest(Message):
+    """Request for listing books."""
+
+    author: Optional[str] = None
+    limit: int = 10
+    offset: int = 0
+
+
+class ListBooksResponse(Message):
+    """Response for listing books."""
+
+    books: List[Book]
+    total_count: int
+
+
+class CreateBookRequest(Message):
+    """Request for creating a book."""
+
+    title: str
+    author: str
+    isbn: Optional[str] = None
+    price: float
+
+
+class UpdateBookRequest(Message):
+    """Request for updating a book."""
+
+    id: str
+    title: Optional[str] = None
+    author: Optional[str] = None
+    price: Optional[float] = None
+
+
+class DeleteBookRequest(Message):
+    """Request for deleting a book."""
+
+    id: str
+
+
+class BookstoreService:
+    """Bookstore management service with HTTP gateway support."""
+
+    @http_option(method="GET", path="/v1/books/{id}")
+    async def get_book(self, request: GetBookRequest) -> Book:
+        """Get a book by ID."""
+        # Implementation would go here
+        return Book(
+            id=request.id, title="Example Book", author="Example Author", price=29.99
+        )
+
+    @http_option(
+        method="GET",
+        path="/v1/books",
+        additional_bindings=[
+            {
+                "get": "/v1/authors/{author}/books"
+            }  # Alternative path for filtering by author
+        ],
+    )
+    async def list_books(self, request: ListBooksRequest) -> ListBooksResponse:
+        """List all books with optional filtering."""
+        # Implementation would go here
+        books = [
+            Book(id="1", title="Python Programming", author="John Doe", price=32.00),
+            Book(id="2", title="gRPC in Practice", author="Jane Smith", price=38.00),
+        ]
+        return ListBooksResponse(books=books, total_count=len(books))
+
+    @http_option(method="POST", path="/v1/books", body="*")
+    async def create_book(self, request: CreateBookRequest) -> Book:
+        """Create a new book."""
+        # Implementation would go here
+        return Book(
+            id="generated-id",
+            title=request.title,
+            author=request.author,
+            isbn=request.isbn,
+            price=request.price,
+        )
+
+    @http_option(method="PUT", path="/v1/books/{id}", body="*")
+    @proto_option("idempotency_level", "IDEMPOTENT")
+    async def update_book(self, request: UpdateBookRequest) -> Book:
+        """Update an existing book."""
+        # Implementation would go here
+        return Book(
+            id=request.id,
+            title=request.title or "Updated Book",
+            author=request.author or "Updated Author",
+            price=request.price or 0.0,
+        )
+
+    @http_option(method="DELETE", path="/v1/books/{id}")
+    async def delete_book(self, request: DeleteBookRequest) -> None:
+        """Delete a book by ID."""
+        # Implementation would go here
+        print(f"Deleting book {request.id}")
+        return None
+
+
+def main():
+    """Generate and display the proto definition."""
+    service = BookstoreService()
+    proto_content = generate_proto(service, package_name="bookstore.v1")
+
+    print("Generated Proto Definition:")
+    print("=" * 80)
+    print(proto_content)
+    print("=" * 80)
+
+    # Optionally save to file
+    with open("bookstore.proto", "w") as f:
+        f.write(proto_content)
+    print("\nProto definition saved to bookstore.proto")
+
+    print("\nThis proto file can now be used with:")
+    print("1. gRPC-Gateway to generate an HTTP gateway")
+    print("2. Connecpy to generate Connect-RPC compatible code")
+    print("3. Standard protoc to generate gRPC client/server code")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/pydantic_rpc/__init__.py
+++ b/src/pydantic_rpc/__init__.py
@@ -6,6 +6,13 @@ from .core import (
     WSGIApp,
     ASGIApp,
     Message,
+    generate_proto,
+)
+from .decorators import (
+    http_option,
+    proto_option,
+    get_method_options,
+    has_http_option,
 )
 
 __all__ = [
@@ -14,6 +21,11 @@ __all__ = [
     "WSGIApp",
     "ASGIApp",
     "Message",
+    "generate_proto",
+    "http_option",
+    "proto_option",
+    "get_method_options",
+    "has_http_option",
 ]
 
 # Optional MCP support

--- a/src/pydantic_rpc/decorators.py
+++ b/src/pydantic_rpc/decorators.py
@@ -1,0 +1,138 @@
+"""Decorators for adding protobuf options to RPC methods."""
+
+from typing import Any, Callable, Dict, List, Optional, TypeVar
+from functools import wraps
+
+from .options import OptionMetadata, OPTION_METADATA_ATTR
+
+
+F = TypeVar("F", bound=Callable[..., Any])
+
+
+def http_option(
+    method: str,
+    path: str,
+    body: Optional[str] = None,
+    response_body: Optional[str] = None,
+    additional_bindings: Optional[List[Dict[str, Any]]] = None,
+) -> Callable[[F], F]:
+    """
+    Decorator to add google.api.http option to an RPC method.
+
+    Args:
+        method: HTTP method (GET, POST, PUT, DELETE, PATCH)
+        path: URL path template (e.g., "/v1/books/{id}")
+        body: Request body mapping (e.g., "*" for entire body)
+        response_body: Response body mapping (specific field to return)
+        additional_bindings: List of additional HTTP bindings
+
+    Example:
+        @http_option(method="GET", path="/v1/books/{id}")
+        async def get_book(self, request: GetBookRequest) -> Book:
+            ...
+    """
+
+    def decorator(func: F) -> F:
+        # Get or create option metadata
+        if not hasattr(func, OPTION_METADATA_ATTR):
+            setattr(func, OPTION_METADATA_ATTR, OptionMetadata())
+
+        metadata: OptionMetadata = getattr(func, OPTION_METADATA_ATTR)
+
+        # Set HTTP option
+        metadata.set_http_option(
+            method=method,
+            path=path,
+            body=body,
+            response_body=response_body,
+            additional_bindings=additional_bindings,
+        )
+
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            return func(*args, **kwargs)
+
+        # Preserve the metadata on the wrapper
+        setattr(wrapper, OPTION_METADATA_ATTR, metadata)
+
+        return wrapper  # type: ignore
+
+    return decorator
+
+
+def proto_option(name: str, value: Any) -> Callable[[F], F]:
+    """
+    Decorator to add a generic protobuf option to an RPC method.
+
+    Args:
+        name: Option name (e.g., "deprecated", "idempotency_level")
+        value: Option value
+
+    Example:
+        @proto_option("deprecated", True)
+        @proto_option("idempotency_level", "IDEMPOTENT")
+        async def old_method(self, request: Request) -> Response:
+            ...
+    """
+
+    def decorator(func: F) -> F:
+        # Get or create option metadata
+        if not hasattr(func, OPTION_METADATA_ATTR):
+            setattr(func, OPTION_METADATA_ATTR, OptionMetadata())
+
+        metadata: OptionMetadata = getattr(func, OPTION_METADATA_ATTR)
+
+        # Add proto option
+        metadata.add_proto_option(name=name, value=value)
+
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            return func(*args, **kwargs)
+
+        # Preserve the metadata on the wrapper
+        setattr(wrapper, OPTION_METADATA_ATTR, metadata)
+
+        return wrapper  # type: ignore
+
+    return decorator
+
+
+def get_method_options(method: Callable) -> Optional[OptionMetadata]:
+    """
+    Get option metadata from a method.
+
+    Args:
+        method: The method to get options from
+
+    Returns:
+        OptionMetadata if present, None otherwise
+    """
+    return getattr(method, OPTION_METADATA_ATTR, None)
+
+
+def has_http_option(method: Callable) -> bool:
+    """
+    Check if a method has an HTTP option.
+
+    Args:
+        method: The method to check
+
+    Returns:
+        True if the method has an HTTP option, False otherwise
+    """
+    metadata = get_method_options(method)
+    return metadata is not None and metadata.http_option is not None
+
+
+def has_proto_options(method: Callable) -> bool:
+    """
+    Check if a method has any proto options.
+
+    Args:
+        method: The method to check
+
+    Returns:
+        True if the method has proto options, False otherwise
+    """
+    metadata = get_method_options(method)
+    return metadata is not None and len(metadata.proto_options) > 0

--- a/src/pydantic_rpc/options.py
+++ b/src/pydantic_rpc/options.py
@@ -1,0 +1,134 @@
+"""Protocol Buffer options support for pydantic-rpc."""
+
+from typing import Any, Dict, List, Optional
+from pydantic import BaseModel, Field
+
+
+class HttpBinding(BaseModel):
+    """HTTP binding configuration for a single HTTP method."""
+
+    method: str = Field(..., description="HTTP method (get, post, put, delete, patch)")
+    path: Optional[str] = Field(None, description="URL path template")
+    body: Optional[str] = Field(None, description="Request body mapping")
+    response_body: Optional[str] = Field(None, description="Response body mapping")
+
+    def to_proto_dict(self) -> Dict[str, Any]:
+        """Convert to protobuf option format."""
+        result = {}
+        if self.path:
+            result[self.method.lower()] = self.path
+        if self.body:
+            result["body"] = self.body
+        if self.response_body:
+            result["response_body"] = self.response_body
+        return result
+
+
+class HttpOption(BaseModel):
+    """Google API HTTP option configuration."""
+
+    method: str = Field(..., description="Primary HTTP method")
+    path: str = Field(..., description="Primary URL path template")
+    body: Optional[str] = Field(None, description="Request body mapping")
+    response_body: Optional[str] = Field(None, description="Response body mapping")
+    additional_bindings: List[Dict[str, Any]] = Field(
+        default_factory=list, description="Additional HTTP bindings"
+    )
+
+    def to_proto_string(self) -> str:
+        """Convert to protobuf option string format."""
+        lines = []
+        lines.append("option (google.api.http) = {")
+
+        # Primary binding
+        lines.append(f'  {self.method.lower()}: "{self.path}"')
+
+        # Body mapping
+        if self.body:
+            lines.append(f'  body: "{self.body}"')
+
+        # Response body mapping
+        if self.response_body:
+            lines.append(f'  response_body: "{self.response_body}"')
+
+        # Additional bindings
+        for binding in self.additional_bindings:
+            lines.append("  additional_bindings {")
+            for key, value in binding.items():
+                if key == "body":
+                    lines.append(f'    {key}: "{value}"')
+                else:
+                    lines.append(f'    {key}: "{value}"')
+            lines.append("  }")
+
+        lines.append("};")
+        return "\n".join(lines)
+
+
+class ProtoOption(BaseModel):
+    """Generic protocol buffer option."""
+
+    name: str = Field(..., description="Option name")
+    value: Any = Field(..., description="Option value")
+
+    def to_proto_string(self) -> str:
+        """Convert to protobuf option string format."""
+        if isinstance(self.value, bool):
+            value_str = "true" if self.value else "false"
+        elif isinstance(self.value, str):
+            # Check if it's an enum value (no quotes) or string literal (quotes)
+            if self.value.isupper() or "_" in self.value:
+                # Likely an enum value
+                value_str = self.value
+            else:
+                value_str = f'"{self.value}"'
+        else:
+            value_str = str(self.value)
+
+        return f"option {self.name} = {value_str};"
+
+
+class OptionMetadata(BaseModel):
+    """Metadata container for method/service options."""
+
+    http_option: Optional[HttpOption] = None
+    proto_options: List[ProtoOption] = Field(default_factory=list)
+
+    def add_proto_option(self, name: str, value: Any) -> None:
+        """Add a generic proto option."""
+        self.proto_options.append(ProtoOption(name=name, value=value))
+
+    def set_http_option(
+        self,
+        method: str,
+        path: str,
+        body: Optional[str] = None,
+        response_body: Optional[str] = None,
+        additional_bindings: Optional[List[Dict[str, Any]]] = None,
+    ) -> None:
+        """Set the HTTP option configuration."""
+        self.http_option = HttpOption(
+            method=method,
+            path=path,
+            body=body,
+            response_body=response_body,
+            additional_bindings=additional_bindings or [],
+        )
+
+    def to_proto_strings(self) -> List[str]:
+        """Convert all options to protobuf strings."""
+        result = []
+
+        # Add HTTP option first if present
+        if self.http_option:
+            result.append(self.http_option.to_proto_string())
+
+        # Add other proto options
+        for option in self.proto_options:
+            result.append(option.to_proto_string())
+
+        return result
+
+
+# Option metadata attribute name used on methods
+OPTION_METADATA_ATTR = "__pydantic_rpc_options__"

--- a/tests/test_proto_options.py
+++ b/tests/test_proto_options.py
@@ -1,0 +1,271 @@
+"""Tests for protobuf options support."""
+
+from typing import List, Optional
+from pydantic_rpc import Message, generate_proto
+from pydantic_rpc.decorators import http_option, proto_option
+
+
+class Book(Message):
+    """Book model for testing."""
+
+    id: str
+    title: str
+    author: str
+    isbn: Optional[str] = None
+    price: float
+
+
+class GetBookRequest(Message):
+    """Request for getting a book."""
+
+    id: str
+
+
+class ListBooksRequest(Message):
+    """Request for listing books."""
+
+    author: Optional[str] = None
+    limit: int = 10
+    offset: int = 0
+
+
+class ListBooksResponse(Message):
+    """Response for listing books."""
+
+    books: List[Book]
+    total_count: int
+
+
+class CreateBookRequest(Message):
+    """Request for creating a book."""
+
+    title: str
+    author: str
+    isbn: Optional[str] = None
+    price: float
+
+
+class UpdateBookRequest(Message):
+    """Request for updating a book."""
+
+    id: str
+    title: Optional[str] = None
+    author: Optional[str] = None
+    price: Optional[float] = None
+
+
+class DeleteBookRequest(Message):
+    """Request for deleting a book."""
+
+    id: str
+
+
+class BookstoreService:
+    """Test service with HTTP options."""
+
+    @http_option(method="GET", path="/v1/books/{id}")
+    async def get_book(self, request: GetBookRequest) -> Book:
+        """Get a book by ID."""
+        return Book(id=request.id, title="Test Book", author="Test Author", price=29.99)
+
+    @http_option(
+        method="GET",
+        path="/v1/books",
+        additional_bindings=[{"get": "/v1/authors/{author}/books"}],
+    )
+    async def list_books(self, request: ListBooksRequest) -> ListBooksResponse:
+        """List all books."""
+        return ListBooksResponse(books=[], total_count=0)
+
+    @http_option(method="POST", path="/v1/books", body="*")
+    async def create_book(self, request: CreateBookRequest) -> Book:
+        """Create a new book."""
+        return Book(
+            id="new-id",
+            title=request.title,
+            author=request.author,
+            isbn=request.isbn,
+            price=request.price,
+        )
+
+    @http_option(method="PUT", path="/v1/books/{id}", body="*")
+    async def update_book(self, request: UpdateBookRequest) -> Book:
+        """Update a book."""
+        return Book(
+            id=request.id,
+            title=request.title or "Updated",
+            author=request.author or "Updated Author",
+            price=request.price or 0.0,
+        )
+
+    @http_option(method="DELETE", path="/v1/books/{id}")
+    async def delete_book(self, request: DeleteBookRequest) -> None:
+        """Delete a book."""
+        return None
+
+
+class SimpleService:
+    """Service without options for comparison."""
+
+    async def simple_method(self, request: GetBookRequest) -> Book:
+        """Simple method without options."""
+        return Book(id=request.id, title="Simple", author="Simple", price=10.0)
+
+
+class MixedOptionsService:
+    """Service with mixed proto options."""
+
+    @http_option(method="POST", path="/v1/auth/login", body="*")
+    @proto_option("deprecated", True)
+    @proto_option("idempotency_level", "IDEMPOTENT")
+    async def login(self, request: GetBookRequest) -> Book:
+        """Login method with multiple options."""
+        return Book(id=request.id, title="Auth", author="Auth", price=0.0)
+
+    @proto_option("deprecated", False)
+    async def new_method(self, request: GetBookRequest) -> Book:
+        """Method with only proto options."""
+        return Book(id=request.id, title="New", author="New", price=0.0)
+
+
+def test_http_option_basic():
+    """Test basic HTTP option generation."""
+    service = BookstoreService()
+    proto = generate_proto(service, package_name="bookstore.v1")
+
+    # Check for google/api/annotations.proto import
+    assert 'import "google/api/annotations.proto";' in proto
+
+    # Check for GET method with path parameter (PascalCase RPC names)
+    assert "rpc GetBook (GetBookRequest) returns (Book) {" in proto
+    assert "option (google.api.http) = {" in proto
+    assert 'get: "/v1/books/{id}"' in proto
+
+    # Check for POST method with body
+    assert "rpc CreateBook (CreateBookRequest) returns (Book) {" in proto
+    assert 'post: "/v1/books"' in proto
+    assert 'body: "*"' in proto
+
+
+def test_http_option_additional_bindings():
+    """Test HTTP option with additional bindings."""
+    service = BookstoreService()
+    proto = generate_proto(service, package_name="bookstore.v1")
+
+    # Check for additional bindings (PascalCase RPC names)
+    assert "rpc ListBooks (ListBooksRequest) returns (ListBooksResponse) {" in proto
+    assert 'get: "/v1/books"' in proto
+    assert "additional_bindings {" in proto
+    assert 'get: "/v1/authors/{author}/books"' in proto
+
+
+def test_delete_with_empty_response():
+    """Test DELETE method returning None/Empty."""
+    service = BookstoreService()
+    proto = generate_proto(service, package_name="bookstore.v1")
+
+    # Check for Empty import
+    assert 'import "google/protobuf/empty.proto";' in proto
+
+    # Check for DELETE method (PascalCase RPC names)
+    assert (
+        "rpc DeleteBook (DeleteBookRequest) returns (google.protobuf.Empty) {" in proto
+    )
+    assert 'delete: "/v1/books/{id}"' in proto
+
+
+def test_service_without_options():
+    """Test service without any options."""
+    service = SimpleService()
+    proto = generate_proto(service, package_name="simple.v1")
+
+    # Should not have google/api/annotations.proto import
+    assert 'import "google/api/annotations.proto";' not in proto
+
+    # Should have simple RPC definition without options block (PascalCase RPC names)
+    assert "rpc SimpleMethod (GetBookRequest) returns (Book);" in proto
+    assert "option (google.api.http)" not in proto
+
+
+def test_mixed_proto_options():
+    """Test service with mixed proto options."""
+    service = MixedOptionsService()
+    proto = generate_proto(service, package_name="mixed.v1")
+
+    # Check for google/api/annotations.proto import (due to login method)
+    assert 'import "google/api/annotations.proto";' in proto
+
+    # Check for HTTP option and other proto options in login method (PascalCase RPC names)
+    assert "rpc Login (GetBookRequest) returns (Book) {" in proto
+    assert "option (google.api.http) = {" in proto
+    assert 'post: "/v1/auth/login"' in proto
+    assert 'body: "*"' in proto
+    assert "option deprecated = true;" in proto
+    assert "option idempotency_level = IDEMPOTENT;" in proto
+
+    # Check for method with only proto options (PascalCase RPC names)
+    assert "rpc NewMethod (GetBookRequest) returns (Book) {" in proto
+    assert "option deprecated = false;" in proto
+
+
+def test_proto_generation_structure():
+    """Test overall proto file structure."""
+    service = BookstoreService()
+    proto = generate_proto(service, package_name="bookstore.v1")
+
+    # Check basic structure
+    assert 'syntax = "proto3";' in proto
+    assert "package bookstore.v1;" in proto
+    assert "service BookstoreService {" in proto
+
+    # Check message definitions
+    assert "message Book {" in proto
+    assert "message GetBookRequest {" in proto
+    assert "message ListBooksRequest {" in proto
+    assert "message ListBooksResponse {" in proto
+    assert "message CreateBookRequest {" in proto
+    assert "message UpdateBookRequest {" in proto
+    assert "message DeleteBookRequest {" in proto
+
+    # Check field definitions
+    assert "string id = 1;" in proto
+    assert "string title = 2;" in proto
+    assert "optional string isbn = 4;" in proto
+    assert "float price = 5;" in proto
+    assert "repeated Book books = 1;" in proto
+    assert "int32 total_count = 2;" in proto
+
+
+def test_all_http_methods():
+    """Test all supported HTTP methods."""
+
+    class AllMethodsService:
+        @http_option(method="GET", path="/v1/resource/{id}")
+        async def get_method(self, request: GetBookRequest) -> Book:
+            return Book(id="1", title="", author="", price=0)
+
+        @http_option(method="POST", path="/v1/resource", body="*")
+        async def post_method(self, request: CreateBookRequest) -> Book:
+            return Book(id="1", title="", author="", price=0)
+
+        @http_option(method="PUT", path="/v1/resource/{id}", body="*")
+        async def put_method(self, request: UpdateBookRequest) -> Book:
+            return Book(id="1", title="", author="", price=0)
+
+        @http_option(method="DELETE", path="/v1/resource/{id}")
+        async def delete_method(self, request: DeleteBookRequest) -> None:
+            return None
+
+        @http_option(method="PATCH", path="/v1/resource/{id}", body="*")
+        async def patch_method(self, request: UpdateBookRequest) -> Book:
+            return Book(id="1", title="", author="", price=0)
+
+    service = AllMethodsService()
+    proto = generate_proto(service, package_name="allmethods.v1")
+
+    # Check all HTTP methods are present
+    assert 'get: "/v1/resource/{id}"' in proto
+    assert 'post: "/v1/resource"' in proto
+    assert 'put: "/v1/resource/{id}"' in proto
+    assert 'delete: "/v1/resource/{id}"' in proto
+    assert 'patch: "/v1/resource/{id}"' in proto


### PR DESCRIPTION
- HTTP Gateway Support: Define REST API mappings using @http_option decorator
- Custom Proto Options: Add any protobuf option with @proto_option decorator
- Automatic Imports: Proto generation automatically includes required imports (e.g., google/api/annotations.proto)

### Usage Example

```python
from pydantic_rpc import Message, http_option, proto_option

class BookService:
    @http_option(method="GET", path="/v1/books/{id}")
    async def get_book(self, request: GetBookRequest) -> Book:
        ...

    @http_option(method="POST", path="/v1/books", body="*")
    @proto_option("idempotency_level", "IDEMPOTENT")
    async def create_book(self, request: CreateBookRequest) -> Book:
        ...
```