### PR TITLE
chore: release v0.15.2

### DIFF
--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -1,12 +1,12 @@
 [project]
 name = "pydantic-rpc-cli"
-version = "0.15.1"
+version = "0.15.2"
 description = "CLI tool for pydantic-rpc with server runtime support"
 authors = [
     { name = "Yasushi Itoh" }
 ]
 dependencies = [
-    "pydantic-rpc>=0.15.1",
+    "pydantic-rpc>=0.15.2",
     "hypercorn>=0.17.3",
     "gunicorn>=20.1.0",
     "uvloop>=0.17.0",  # Optional performance improvement for asyncio

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pydantic-rpc"
-version = "0.15.1"
+version = "0.15.2"
 description = "A Python library for building gRPC/ConnectRPC services with Pydantic models."
 authors = [
     { name = "Yasushi Itoh" }

--- a/uv.lock
+++ b/uv.lock
@@ -835,7 +835,7 @@ wheels = [
 
 [[package]]
 name = "pydantic-rpc"
-version = "0.15.1"
+version = "0.15.2"
 source = { editable = "." }
 dependencies = [
     { name = "annotated-types" },


### PR DESCRIPTION
## Summary
- Bump version to v0.15.2

## What's Changed since v0.15.1
- fix: Properly filter out private methods from servicer class (#56)